### PR TITLE
Remove uneeded added time format

### DIFF
--- a/locales/fr_actionpack.yml
+++ b/locales/fr_actionpack.yml
@@ -96,14 +96,6 @@ fr:
       minute: "Minute"
       second: "Seconde"
 
-  time:
-    am: am
-    formats:
-      default: "%d %B %Y %H h %M min %S s"
-      long: "%A %d %B %Y %H h %M"
-      short: "%d %b %H h %M"
-    pm: pm
-
   helpers:
     select:
       prompt: "Veuillez sélectionner"


### PR DESCRIPTION
Remove time formats as there are already defined in fr_activesupport.yml.