### PR TITLE
Use number_with_delimiter() with pluralize()

### DIFF
--- a/lib/french_rails/action_view/text_helper.rb
+++ b/lib/french_rails/action_view/text_helper.rb
@@ -5,7 +5,7 @@ module ActionView
     module TextHelper
 
       # Monkey-patch the pluralize from ActionView::Helpers::TextHelper
-      # to the french grammar rules (i.e. absolute value < 2 is singular).
+      # to the French grammar rules (i.e. absolute value < 2 is singular).
       #
       # Example:
       #   pluralize(0, 'euro')     =>  0 euro
@@ -17,7 +17,7 @@ module ActionView
       #   pluralize(-2, 'euro')    =>  2 euros
       #
       def pluralize(count, singular, plural = nil)
-        "#{count || 0} " + ((count.abs < 2) ? singular : (plural || singular.pluralize))
+        "#{number_with_delimiter(count, delimiter: " ", separator: ",") || 0} " + ((count.abs < 2) ? singular : (plural || singular.pluralize))
       end
 
     end


### PR DESCRIPTION
Use number_with_delimiter() with pluralize().
number_with_delimiter() should use the default locale parameters, but as it’s “french-rails”, we can force the delimiter to a thin space and the separator to a comma.
Also use a non-breaking space between the number and the name to be pluralized.